### PR TITLE
Add jQuery support for Ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Note: This directive was created for a prototype project and has only been teste
 
 ### Disable ngPlus Overlay
 
-The ngPlus overlay can be disabled for specific requests by setting the `ngplusIgnore` option to `true`
+The ngPlus overlay can be disabled for specific requests by setting the `hideOverlay` option to `true`
 on either the angular http request config or the jquery ajax options objects.
 
 - Angular
@@ -113,7 +113,7 @@ on either the angular http request config or the jquery ajax options objects.
 $http({
     url: 'http://www.google.com',
     // ...
-    ngplusIgnore: true,
+    hideOverlay: true,
 });
 ```
 
@@ -122,12 +122,12 @@ $http({
 $.ajax({
     url: 'http://www.google.com',
     // ...
-    ngplusIgnore: true,
+    hideOverlay: true,
 });
 ```
 
 If you don't have control over the xhr being made you can create an angular interceptor to modify
 the request config and register that before the ngPlus interceptor.  In jQuery you can register
 an `$.ajaxSend` handler before the ngPlus handler to check the request object and add the
-ngplusIgnore attribute if needed.
+hideOverlay attribute if needed.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note: This directive was created for a prototype project and has only been teste
 ### Disable ngPlus Overlay
 
 The ngPlus overlay can be disabled for specific requests by setting the `ngplusIgnore` option to `true`
-on either the angular http request config or the jquery ajax pptions objects.
+on either the angular http request config or the jquery ajax options objects.
 
 - Angular
 ```js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use, reproduction, distribution, and modification of this code is subject to the
 
 
 
-#ngplusOverlay Directive
+# ngplusOverlay Directive
 
 ![ngplusOverlay Directive Example](https://raw.github.com/DanWahlin/AngularOverlay/master/content/images/appExample.png)
 
@@ -97,9 +97,37 @@ ngplusOverlay directive in action.
 
 Note: This directive was created for a prototype project and has only been tested with Chrome and IE10+. It's intended to provide a starting point, evolve over time (please contribute!), and hopefully save someone some time.
 
-###Options
+### Options
 
 - `ngplus-overlay-delay-in="50"` indicates the number of milliseconds to wait before showing the overlay. This is useful so we do not have a flicker for super short XHR. Default is 500 ms.
 - `ngplus-overlay-delay-out="700"` indicates the number of milliseconds to keep the overlay around after the last XHR has completed. Default is 500 ms.
 - `ngplus-overlay-animation="dissolve-animation"` indicates the CSS animation to apply. Must be an animation that supports the AngularJS standard for ngShow/ngHide. This is an optional setting. 
+
+### Disable ngPlus Overlay
+
+The ngPlus overlay can be disabled for specific requests by setting the `ngplusIgnore` option to `true`
+on either the angular http request config or the jquery ajax pptions objects.
+
+- Angular
+```js
+$http({
+    url: 'http://www.google.com',
+    // ...
+    ngplusIgnore: true,
+});
+```
+
+- jQuery
+```js
+$.ajax({
+    url: 'http://www.google.com',
+    // ...
+    ngplusIgnore: true,
+});
+```
+
+If you don't have control over the xhr being made you can create an angular interceptor to modify
+the request config and register that before the ngPlus interceptor.  In jQuery you can register
+an `$.ajaxSend` handler before the ngPlus handler to check the request object and add the
+ngplusIgnore attribute if needed.
 

--- a/ngplus-overlay.js
+++ b/ngplus-overlay.js
@@ -77,21 +77,21 @@
             function wireUpHttpInterceptor() {
 
                 httpInterceptor.request = function (config) {
-                    if (!config.ngplusIgnore) {
+                    if (!config.hideOverlay) {
                         processRequest();
                     }
                     return config || $q.when(config);
                 };
 
                 httpInterceptor.response = function (response) {
-                    if (response && response.config && !response.config.ngplusIgnore) {
+                    if (response && response.config && !response.config.hideOverlay) {
                         processResponse();
                     }
                     return response || $q.when(response);
                 };
 
                 httpInterceptor.responseError = function (rejection) {
-                    if (rejection && rejection.config && !rejection.config.ngplusIgnore) {
+                    if (rejection && rejection.config && !rejection.config.hideOverlay) {
                         processResponse();
                     }
                     return $q.reject(rejection);
@@ -102,14 +102,14 @@
             function wirejQueryInterceptor() {
 
                 $(document).ajaxSend(function(e, xhr, options) {
-                  if (options && !options.ngplusIgnore) {
+                  if (options && !options.hideOverlay) {
                     processRequest();
                   }
                 });
 
                 // ajax complete always gets fired, even on errors
                 $(document).ajaxComplete(function(e, xhr, options) {
-                  if (options && !options.ngplusIgnore) {
+                  if (options && !options.hideOverlay) {
                     processResponse();
                   }
                 });

--- a/ngplus-overlay.js
+++ b/ngplus-overlay.js
@@ -77,28 +77,42 @@
             function wireUpHttpInterceptor() {
 
                 httpInterceptor.request = function (config) {
-                    if (!config.hideOverlay) {
+                    if (!config.ngplusIgnore) {
                         processRequest();
                     }
                     return config || $q.when(config);
                 };
 
                 httpInterceptor.response = function (response) {
-                    processResponse();
+                    if (response && response.config && !response.config.ngplusIgnore) {
+                        processResponse();
+                    }
                     return response || $q.when(response);
                 };
 
                 httpInterceptor.responseError = function (rejection) {
-                    processResponse();
+                    if (rejection && rejection.config && !rejection.config.ngplusIgnore) {
+                        processResponse();
+                    }
                     return $q.reject(rejection);
                 };
             }
 
             //Monitor jQuery Ajax calls in case it's used in an app
             function wirejQueryInterceptor() {
-                $(document).ajaxStart(function () { processRequest(); });
-                $(document).ajaxComplete(function () { processResponse(); });
-                $(document).ajaxError(function () { processResponse(); });
+
+                $(document).ajaxSend(function(e, xhr, options) {
+                  if (options && !options.ngplusIgnore) {
+                    processRequest();
+                  }
+                });
+
+                // ajax complete always gets fired, even on errors
+                $(document).ajaxComplete(function(e, xhr, options) {
+                  if (options && !options.ngplusIgnore) {
+                    processResponse();
+                  }
+                });
             }
 
             function processRequest() {

--- a/ngplus-overlay.js
+++ b/ngplus-overlay.js
@@ -16,19 +16,19 @@
 
     //Empty factory to hook into $httpProvider.interceptors
     //Directive will hookup request, response, and responseError interceptors
-    overlayApp.factory('httpInterceptor', httpInterceptor);
+    overlayApp.factory('ngplus.httpInterceptor', httpInterceptor);
     function httpInterceptor () { return {} }
 
     //Hook httpInterceptor factory into the $httpProvider interceptors so that we can monitor XHR calls
     overlayApp.config(['$httpProvider', httpProvider]);
     function httpProvider ($httpProvider) {
-        $httpProvider.interceptors.push('httpInterceptor');
+        $httpProvider.interceptors.push('ngplus.httpInterceptor');
     }
 
     //Directive that uses the httpInterceptor factory above to monitor XHR calls
     //When a call is made it displays an overlay and a content area
     //No attempt has been made at this point to test on older browsers
-    overlayApp.directive('ngplusOverlay', ['$q', '$timeout', '$window', 'httpInterceptor', overlay]);
+    overlayApp.directive('ngplusOverlay', ['$q', '$timeout', '$window', 'ngplus.httpInterceptor', overlay]);
 
     function overlay ($q, $timeout, $window, httpInterceptor) {
         var directive = {
@@ -77,7 +77,9 @@
             function wireUpHttpInterceptor() {
 
                 httpInterceptor.request = function (config) {
-                    processRequest();
+                    if (!config.hideOverlay) {
+                        processRequest();
+                    }
                     return config || $q.when(config);
                 };
 


### PR DESCRIPTION
This enhances #3 and adds ignore support for jQuery which should fully close #2 for the user using SignalR.

It also fixes a bug in #3 where ignored requests were not having their responses ignored thus potentially causing the overlay to disappear prematurely.

I also renamed the ignore option from `hideOverlay` to ngplusIgnore, Ignore makes more sense then Hide.  Its a breaking change, but with the last PR not released and just a few hours ago I assume its not a problem.

Finally I updated the readme with instructions on how to ignore overlays.

It would be great if we could get a version bump and new release if this looks good.

Thanks,
Adam